### PR TITLE
Priority queue + thread locals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +255,7 @@ name = "samp-precise-timers"
 version = "1.0.0"
 dependencies = [
  "fern",
+ "fnv",
  "log",
  "once_cell",
  "priority-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -146,6 +146,12 @@ name = "num-traits"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "priority-queue"
@@ -244,6 +250,7 @@ version = "1.0.0"
 dependencies = [
  "fern",
  "log",
+ "once_cell",
  "priority-queue",
  "samp",
  "slab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg 1.1.0",
+ "hashbrown",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +146,16 @@ name = "num-traits"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+
+[[package]]
+name = "priority-queue"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7685ca4cc0b3ad748c22ce6803e23b55b9206ef7715b965ebeaf41639238fdc"
+dependencies = [
+ "autocfg 1.1.0",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -218,6 +244,7 @@ version = "1.0.0"
 dependencies = [
  "fern",
  "log",
+ "priority-queue",
  "samp",
  "slab",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ samp = { git = "https://github.com/ZOTTCE/samp-rs.git", rev = "2e9192713bf9a77ee
 slab = "0.4.2"
 log = "0.4.6"
 fern = "0.5.9"
+priority-queue = "1.3.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ slab = "0.4.2"
 log = "0.4.6"
 fern = "0.5.9"
 priority-queue = "1.3.0"
+once_cell = "1.19.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4.6"
 fern = "0.5.9"
 priority-queue = "1.3.0"
 once_cell = "1.19.0"
+fnv = "1.0.7"
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use samp::error::{AmxError, AmxResult};
 use samp::plugin::SampPlugin;
 use slab::Slab;
 use std::cmp::Reverse;
-use std::collections::hash_map::RandomState;
 use std::convert::TryFrom;
 use std::time::{Duration, Instant};
 use timer::Timer;
@@ -18,7 +17,7 @@ mod timer;
 /// The plugin and its data: a list of scheduled timers
 struct PreciseTimers {
     timers: Slab<Timer>,
-    queue: PriorityQueue<usize, Reverse<std::time::Instant>, RandomState>,
+    queue: PriorityQueue<usize, Reverse<std::time::Instant>, fnv::FnvBuildHasher>,
 }
 
 impl PreciseTimers {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,11 +146,6 @@ impl PreciseTimers {
     }
 }
 
-enum TimerToBeExecuted {
-    Removed(Timer),
-    Retained(usize),
-}
-
 impl SampPlugin for PreciseTimers {
     fn on_load(&mut self) {
         info!("net4game.com/samp-precise-timers by Brian Misiak loaded correctly.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl SampPlugin for PreciseTimers {
             }
         }
 
-        for &key in TRIGGERED_TIMERS.iter() {
+        for &key in &TRIGGERED_TIMERS {
             if let Some(timer) = self.timers.get_mut(key) {
                 // if this deleted the next timer scheduled for execution,
                 // and immediately scheduled another one which receives the same key,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ impl PreciseTimers {
 
 enum TimerToBeExecuted {
     Removed(Timer),
-    Remaining(usize),
+    Retained(usize),
 }
 
 impl SampPlugin for PreciseTimers {
@@ -145,7 +145,7 @@ impl SampPlugin for PreciseTimers {
             if let (Some(interval), false) = (interval, scheduled_for_removal) {
                 let next_trigger = now + interval;
                 self.queue.change_priority(&key, Reverse(next_trigger));
-                timers_to_be_executed.push(TimerToBeExecuted::Remaining(key));
+                timers_to_be_executed.push(TimerToBeExecuted::Retained(key));
             } else {
                 self.queue
                     .pop()
@@ -162,7 +162,7 @@ impl SampPlugin for PreciseTimers {
                         error!("Error executing removed timer callback: {}", err);
                     }
                 }
-                TimerToBeExecuted::Remaining(key) => {
+                TimerToBeExecuted::Retained(key) => {
                     let timer = self
                         .timers
                         .get_mut(key)

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,7 +1,7 @@
 use crate::amx_arguments::VariadicAmxArguments;
-use log::error;
+
 use samp::{amx::AmxIdent, error::AmxError, prelude::AmxResult};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 #[derive(PartialEq)]
 pub(crate) enum TimerStaus {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -3,12 +3,6 @@ use crate::amx_arguments::VariadicAmxArguments;
 use samp::{amx::AmxIdent, error::AmxError, prelude::AmxResult};
 use std::time::Duration;
 
-#[derive(PartialEq)]
-pub(crate) enum TimerStaus {
-    MightTriggerInTheFuture,
-    WillNeverTriggerAgain,
-}
-
 /// The Timer struct represents a single scheduled timer
 #[derive(Debug, Clone)]
 pub(crate) struct Timer {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,16 +1,13 @@
 use crate::amx_arguments::VariadicAmxArguments;
 
 use samp::{amx::AmxIdent, error::AmxError, prelude::AmxResult};
-use std::time::Duration;
 
 /// The Timer struct represents a single scheduled timer
 #[derive(Debug, Clone)]
 pub(crate) struct Timer {
-    pub interval: Option<Duration>,
     pub passed_arguments: VariadicAmxArguments,
     pub amx_identifier: AmxIdent,
     pub amx_callback_index: samp::consts::AmxExecIdx,
-    pub scheduled_for_removal: bool,
 }
 
 impl Timer {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,10 +1,6 @@
 use crate::amx_arguments::VariadicAmxArguments;
 use log::error;
-use samp::{
-    amx::AmxIdent,
-    error::AmxError,
-    prelude::AmxResult,
-};
+use samp::{amx::AmxIdent, error::AmxError, prelude::AmxResult};
 use std::time::{Duration, Instant};
 
 #[derive(PartialEq)]
@@ -16,7 +12,6 @@ pub(crate) enum TimerStaus {
 /// The Timer struct represents a single scheduled timer
 #[derive(Debug, Clone)]
 pub(crate) struct Timer {
-    pub next_trigger: Instant,
     pub interval: Option<Duration>,
     pub passed_arguments: VariadicAmxArguments,
     pub amx_identifier: AmxIdent,
@@ -30,7 +25,7 @@ impl Timer {
     }
 
     /// This function executes the callback provided to the `SetPreciseTimer` native.
-    pub fn trigger(&mut self) -> AmxResult<()> {
+    pub fn execute_pawn_callback(&mut self) -> AmxResult<()> {
         // Get the AMX which scheduled the timer
         let amx = samp::amx::get(self.amx_identifier).ok_or(AmxError::NotFound)?;
         let allocator = amx.allocator();
@@ -41,42 +36,5 @@ impl Timer {
         amx.exec(self.amx_callback_index)?;
 
         Ok(())
-    }
-
-    /// Checks if it's time to trigger the timer yet. If so, triggers it.
-    /// Returns info about whether the timer is okay to remove now
-    #[inline(always)]
-    pub fn trigger_if_due(&mut self, now: Instant) -> TimerStaus {
-        use TimerStaus::{MightTriggerInTheFuture, WillNeverTriggerAgain};
-
-        if self.scheduled_for_removal {
-            // Ordered removed. Do not execute the timer's callback.
-            return WillNeverTriggerAgain;
-        }
-        if self.next_trigger > now {
-            // Not the time to trigger it yet.
-            return MightTriggerInTheFuture;
-        }
-
-        // Execute the callback:
-        if let Err(err) = self.trigger() {
-            error!("Error executing timer callback: {}", err);
-        }
-
-        if let Some(interval) = self.interval {
-            self.next_trigger = now + interval;
-            // It repeats. Keep it, unless removed from PAWN when it was triggered just now.
-            // Hopfully LLVM doesn't elide this check, but it could, given that we checked
-            // scheduled_for_removal earlier, .trigger() doesn't modify it, and Amx::exec
-            // is wrongly marked safe despite its potential for aliased references.
-            if self.scheduled_for_removal {
-                WillNeverTriggerAgain
-            } else {
-                MightTriggerInTheFuture
-            }
-        } else {
-            // Remove the timer. It got triggered and does not repeat
-            WillNeverTriggerAgain
-        }
     }
 }


### PR DESCRIPTION
1. Uses a priority queue to keep the next timer hot
2. Uses thread locals to avoid breaking any Rust reference invariants despite FFI