### PR TITLE
Add IsValidPreciseTimer native

### DIFF
--- a/samp-precise-timers.inc
+++ b/samp-precise-timers.inc
@@ -30,3 +30,12 @@ native ResetPreciseTimer(const timer_number, const interval, const repeat);
     # DeletePreciseTimer returns 1 if the timer existed or 0 on failure.
 */
 native DeletePreciseTimer(const timer_number);
+
+/*
+    # IsValidPreciseTimer returns 1 if the timer is valid and exists, 0 otherwise.
+        Returns 0 if:
+        - timer had already been removed
+        - timer_number is invalid (0 or negative)
+        - timer_number is not in the system
+*/
+native IsValidPreciseTimer(const timer_number);


### PR DESCRIPTION
## Summary
This PR adds a new native function `IsValidPreciseTimer(timerid)` that makes it possible to test whether a specified timer ID is still active and valid.

It also fixes a problem where callback functions continue to execute even after `DeletePreciseTimer(timerid)` is executed within the callback itself.

## Usage Example (PAWN)

```pawn
new MyTimer;

public OnPlayerConnect(playerid)
{
    MyTimer = SetPreciseTimer("HelloTimer", 2000, true, "i", playerid);
}

public HelloTimer(playerid)
{
    // check if it is still valid before deleting
    if(IsValidPreciseTimer(MyTimer))
    {
        DeletePreciseTimer(MyTimer);
        printf("Timer stopped for player %d.", playerid);
    }
}